### PR TITLE
Dependency upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
           toolchain: "1.94"
-      - run: cargo test --all-targets --features tokio
+      - run: cargo test --all-targets
 
   fmt:
     name: cargo fmt
@@ -37,7 +37,7 @@ jobs:
         with:
           toolchain: "1.94"
           components: clippy
-      - run: cargo clippy --all-targets --features tokio -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings
 
   minimal-dependencies:
     name: minimal direct dependencies
@@ -49,8 +49,8 @@ jobs:
           toolchain: "nightly-2026-05-05"
           components: clippy
       - run: rm Cargo.lock
-      - run: cargo check -Z direct-minimal-versions --features tokio
-      - run: cargo check -Z direct-minimal-versions --features async-std
+      - run: cargo check -Z direct-minimal-versions
+      - run: cargo check -Z direct-minimal-versions --no-default-features --features smol
 
   allgreen:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           toolchain: "1.94"
       - run: cargo test --all-targets
+      - run: cargo test --all-targets --no-default-features --features smol
 
   fmt:
     name: cargo fmt
@@ -38,6 +39,7 @@ jobs:
           toolchain: "1.94"
           components: clippy
       - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets --no-default-features --features smol -- -D warnings
 
   minimal-dependencies:
     name: minimal direct dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -57,17 +57,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
 
 [[package]]
 name = "async-channel"
@@ -96,18 +85,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
+name = "async-fs"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
  "async-lock",
  "blocking",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -123,9 +108,9 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.4",
+ "rustix",
  "slab",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -134,35 +119,56 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "async-std"
-version = "1.13.2"
+name = "async-net"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
  "async-io",
  "async-lock",
- "crossbeam-utils",
- "futures-channel",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
  "futures-core",
  "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
+ "rustix",
+ "signal-hook-registry",
  "slab",
- "wasm-bindgen-futures",
+ "windows-sys",
 ]
 
 [[package]]
@@ -195,7 +201,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -300,14 +306,14 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -344,12 +350,12 @@ name = "dfu-nusb"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "clap",
  "dfu-core",
  "futures 0.3.32",
  "indicatif",
  "nusb",
+ "smol",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -379,14 +385,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
@@ -405,7 +405,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -526,18 +526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
 dependencies = [
  "core-foundation-sys",
  "mach2",
@@ -590,9 +578,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -601,25 +589,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -641,15 +614,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -668,26 +638,28 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "nusb"
-version = "0.1.14"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f861541f15de120eae5982923d073bfc0c1a65466561988c82d6e197734c19e"
+checksum = "8a330b3bc7f8b4fc729a4c63164b3927eeeaced198222a3ce6b8b6e034851b7a"
 dependencies = [
- "atomic-waker",
+ "blocking",
  "core-foundation",
  "core-foundation-sys",
  "futures-core",
+ "futures-io",
  "io-kit-sys",
- "libc",
+ "linux-raw-sys",
  "log",
  "once_cell",
- "rustix 0.38.44",
+ "rustix",
  "slab",
- "windows-sys 0.48.0",
+ "tokio",
+ "windows-sys",
 ]
 
 [[package]]
@@ -738,12 +710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,8 +730,8 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -809,19 +775,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -829,8 +782,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -868,13 +821,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -916,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -928,7 +898,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -992,12 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,9 +969,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1017,20 +981,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1038,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1051,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1076,148 +1030,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dfu-nusb"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/dfu-rs/dfu-nusb"
 readme = "README.md"
 
 [features]
-default = []
+default = ["tokio"]
 tokio = ["dep:tokio", "nusb/tokio"]
 smol = ["dep:smol", "nusb/smol"]
 
@@ -28,7 +28,3 @@ futures = { version = "0.3.31", features = ["io-compat"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.12", features = ["compat"] }
 indicatif = { version = "0.18.4", features = [ "tokio" ] }
-
-[[example]]
-name = "download"
-required-features = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ futures = { version = "0.3.31", features = ["io-compat"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.12", features = ["compat"] }
 indicatif = { version = "0.18.4", features = [ "tokio" ] }
+
+[[example]]
+name = "download"
+required-features = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfu-nusb"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/dfu-rs/dfu-nusb"
 readme = "README.md"
 
 [features]
-default = ["tokio"]
+default = []
 tokio = ["dep:tokio", "nusb/tokio"]
 smol = ["dep:smol", "nusb/smol"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ repository = "https://github.com/dfu-rs/dfu-nusb"
 readme = "README.md"
 
 [features]
-default = []
-tokio = ["dep:tokio"]
-async-std = ["dep:async-std"]
+default = ["tokio"]
+tokio = ["dep:tokio", "nusb/tokio"]
+smol = ["dep:smol", "nusb/smol"]
 
 [dependencies]
 dfu-core = { version = "0.11.0", features = ["async"] }
-nusb = "0.1.10"
+nusb = "0.2.3"
 thiserror = "2.0.18"
 tokio = { version = "1.48.0", features = ["time"], optional = true }
-async-std = { version = "1.13.2", features = ["alloc"], optional = true }
+smol = {version="2.0.2", optional = true}
 
 [dev-dependencies]
 anyhow = "1.0.91"

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -43,11 +43,8 @@ pub struct Cli {
 
 pub async fn try_open(vid: u16, pid: u16, int: u8, alt: u8) -> Result<DfuNusb, dfu_nusb::Error> {
     let info = nusb::list_devices()
-        .await
-        .ok()
-        .and_then(|mut devices| {
-            devices.find(|dev| dev.vendor_id() == vid && dev.product_id() == pid)
-        })
+        .await?
+        .find(|dev| dev.vendor_id() == vid && dev.product_id() == pid)
         .ok_or(dfu_nusb::Error::DeviceNotFound)?;
     let device = info.open().await?;
     let interface = device.claim_interface(int).await?;

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -41,15 +41,18 @@ pub struct Cli {
     override_address: Option<u32>,
 }
 
-pub fn try_open(vid: u16, pid: u16, int: u8, alt: u8) -> Result<DfuNusb, dfu_nusb::Error> {
+pub async fn try_open(vid: u16, pid: u16, int: u8, alt: u8) -> Result<DfuNusb, dfu_nusb::Error> {
     let info = nusb::list_devices()
-        .unwrap()
-        .find(|dev| dev.vendor_id() == vid && dev.product_id() == pid)
+        .await
+        .ok()
+        .and_then(|mut devices| {
+            devices.find(|dev| dev.vendor_id() == vid && dev.product_id() == pid)
+        })
         .ok_or(dfu_nusb::Error::DeviceNotFound)?;
-    let device = info.open()?;
-    let interface = device.claim_interface(int)?;
+    let device = info.open().await?;
+    let interface = device.claim_interface(int).await?;
 
-    DfuNusb::open(device, interface, alt)
+    DfuNusb::open(device, interface, alt).await
 }
 
 pub async fn run(opts: Cli) -> anyhow::Result<()> {
@@ -70,14 +73,14 @@ pub async fn run(opts: Cli) -> anyhow::Result<()> {
         .context("the firmware file is too big")?;
     file.seek(io::SeekFrom::Start(0)).await?;
 
-    let device = match try_open(vid, pid, intf, alt) {
+    let device = match try_open(vid, pid, intf, alt).await {
         Err(dfu_nusb::Error::DeviceNotFound) if wait => {
             let bar = indicatif::ProgressBar::new_spinner();
             bar.set_message("Waiting for device");
 
             loop {
                 tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-                match try_open(vid, pid, intf, alt) {
+                match try_open(vid, pid, intf, alt).await {
                     Err(dfu_nusb::Error::DeviceNotFound) => bar.tick(),
                     r => {
                         bar.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,17 +132,13 @@ impl DfuIo for DfuNusb {
             request,
             value,
             index: self.interface.interface_number() as u16,
-            length: buffer.len() as u16,
+            length: buffer.len().try_into().unwrap_or(u16::MAX),
         };
         let r = self
             .interface
             .control_in(req, Duration::from_secs(3))
             .wait()?;
-        assert!(
-            buffer.len() >= r.len(),
-            "Expect nusb to never read more bytes than specified in the `ControlIn` struct"
-        );
-        let len = r.len();
+        let len = r.len().min(buffer.len());
         buffer[0..len].copy_from_slice(&r[0..len]);
         Ok(len)
     }
@@ -207,17 +203,13 @@ impl DfuAsyncIo for DfuNusb {
             request,
             value,
             index: self.interface.interface_number() as u16,
-            length: buffer.len() as u16,
+            length: buffer.len().try_into().unwrap_or(u16::MAX),
         };
         let r = self
             .interface
             .control_in(req, Duration::from_secs(3))
             .await?;
-        assert!(
-            buffer.len() >= r.len(),
-            "Expect nusb to never read more bytes than specified in the `ControlIn` struct"
-        );
-        let len = r.len();
+        let len = r.len().min(buffer.len());
         buffer[0..len].copy_from_slice(&r[0..len]);
         Ok(len)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use dfu_core::{
     asynchronous::DfuAsyncIo, functional_descriptor::FunctionalDescriptor, DfuIo, DfuProtocol,
 };
-use nusb::transfer::{Control, ControlIn, ControlOut, ControlType, Recipient, TransferError};
+use nusb::transfer::{ControlIn, ControlOut, ControlType, Recipient, TransferError};
+use nusb::MaybeFuture;
 use thiserror::Error;
 
 pub type DfuASync = dfu_core::asynchronous::DfuAsync<DfuNusb, Error>;
@@ -20,9 +21,13 @@ pub enum Error {
     #[error(transparent)]
     FunctionalDescriptor(#[from] dfu_core::functional_descriptor::Error),
     #[error(transparent)]
+    GetDescriptorError(#[from] nusb::GetDescriptorError),
+    #[error(transparent)]
     Dfu(#[from] dfu_core::Error),
     #[error(transparent)]
     Nusb(#[from] nusb::Error),
+    #[error(transparent)]
+    StdIO(#[from] std::io::Error),
     #[error(transparent)]
     Transfer(#[from] TransferError),
 }
@@ -36,8 +41,12 @@ pub struct DfuNusb {
 
 impl DfuNusb {
     /// Open a device
-    pub fn open(device: nusb::Device, interface: nusb::Interface, alt: u8) -> Result<Self, Error> {
-        interface.set_alt_setting(alt)?;
+    pub async fn open(
+        device: nusb::Device,
+        interface: nusb::Interface,
+        alt: u8,
+    ) -> Result<Self, Error> {
+        interface.set_alt_setting(alt).await?;
         let descriptor = interface
             .descriptors()
             .find_map(|alt| {
@@ -52,11 +61,13 @@ impl DfuNusb {
 
         let s = if let Some(index) = alt.string_index() {
             let lang = device
-                .get_string_descriptor_supported_languages(Duration::from_secs(3))?
+                .get_string_descriptor_supported_languages(Duration::from_secs(3))
+                .await?
                 .next()
                 .unwrap_or_default();
             device
                 .get_string_descriptor(index, lang, Duration::from_secs(3))
+                .await
                 .unwrap_or_default()
         } else {
             String::new()
@@ -115,17 +126,25 @@ impl DfuIo for DfuNusb {
         buffer: &mut [u8],
     ) -> Result<Self::Read, Self::Error> {
         let (control_type, recipient) = split_request_type(request_type);
-        let req = Control {
+        let req = ControlIn {
             control_type,
             recipient,
             request,
             value,
             index: self.interface.interface_number() as u16,
+            length: buffer.len() as u16,
         };
         let r = self
             .interface
-            .control_in_blocking(req, buffer, Duration::from_secs(3))?;
-        Ok(r)
+            .control_in(req, Duration::from_secs(3))
+            .wait()?;
+        assert!(
+            buffer.len() >= r.len(),
+            "Expect nusb to never read more bytes than specified in the `ControlIn` struct"
+        );
+        let len = r.len();
+        buffer[0..len].copy_from_slice(&r[0..len]);
+        Ok(len)
     }
 
     fn write_control(
@@ -136,24 +155,25 @@ impl DfuIo for DfuNusb {
         buffer: &[u8],
     ) -> Result<Self::Write, Self::Error> {
         let (control_type, recipient) = split_request_type(request_type);
-        let req = Control {
+        let req = ControlOut {
             control_type,
             recipient,
             request,
             value,
             index: self.interface.interface_number() as u16,
+            data: buffer,
         };
-        let r = self
-            .interface
-            .control_out_blocking(req, buffer, Duration::from_secs(3))?;
-        Ok(r)
+        self.interface
+            .control_out(req, Duration::from_secs(3))
+            .wait()?;
+        Ok(buffer.len())
     }
 
     fn usb_reset(self) -> Result<Self::Reset, Self::Error> {
         // Drop the interface before resetting the device. On macOS, the device cannot be reset
         // while any interface is still claimed
         drop(self.interface);
-        self.device.reset()?;
+        self.device.reset().wait()?;
         Ok(())
     }
 
@@ -189,8 +209,15 @@ impl DfuAsyncIo for DfuNusb {
             index: self.interface.interface_number() as u16,
             length: buffer.len() as u16,
         };
-        let r = self.interface.control_in(req).await.into_result()?;
-        let len = buffer.len().min(r.len());
+        let r = self
+            .interface
+            .control_in(req, Duration::from_secs(3))
+            .await?;
+        assert!(
+            buffer.len() >= r.len(),
+            "Expect nusb to never read more bytes than specified in the `ControlIn` struct"
+        );
+        let len = r.len();
         buffer[0..len].copy_from_slice(&r[0..len]);
         Ok(len)
     }
@@ -211,15 +238,17 @@ impl DfuAsyncIo for DfuNusb {
             index: self.interface.interface_number() as u16,
             data: buffer,
         };
-        let r = self.interface.control_out(req).await.into_result()?;
-        Ok(r.actual_length())
+        self.interface
+            .control_out(req, Duration::from_secs(3))
+            .await?;
+        Ok(buffer.len())
     }
 
     async fn usb_reset(self) -> Result<Self::Reset, Self::Error> {
         // Drop the interface before resetting the device. On macOS, the device cannot be reset
         // while any interface is still claimed
         drop(self.interface);
-        self.device.reset()?;
+        self.device.reset().await?;
         Ok(())
     }
 
@@ -228,12 +257,12 @@ impl DfuAsyncIo for DfuNusb {
         tokio::time::sleep(duration).await
     }
 
-    #[cfg(feature = "async-std")]
+    #[cfg(feature = "smol")]
     async fn sleep(&self, duration: Duration) {
-        async_std::task::sleep(duration).await
+        smol::Timer::after(duration).await;
     }
 
-    #[cfg(not(any(feature = "tokio", feature = "async-std")))]
+    #[cfg(not(any(feature = "tokio", feature = "smol")))]
     async fn sleep(&self, duration: Duration) {
         compile_error!(
             "You must select an async runtime through the features: tokio, asyncstd, ...",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl DfuAsyncIo for DfuNusb {
         Ok(())
     }
 
-    #[cfg(feature = "tokio")]
+    #[cfg(all(feature = "tokio", not(feature = "smol")))]
     async fn sleep(&self, duration: Duration) {
         tokio::time::sleep(duration).await
     }
@@ -264,9 +264,7 @@ impl DfuAsyncIo for DfuNusb {
 
     #[cfg(not(any(feature = "tokio", feature = "smol")))]
     async fn sleep(&self, duration: Duration) {
-        compile_error!(
-            "You must select an async runtime through the features: tokio, asyncstd, ...",
-        )
+        compile_error!("You must select an async runtime through the features: tokio, smol, ...",)
     }
 
     fn protocol(&self) -> &dfu_core::DfuProtocol<Self::MemoryLayout> {


### PR DESCRIPTION
This upgrades nusb and dfu-core dependencies to the latest version.

### Breaking Changes

- `open()` is now async
- `usb_reset()` takes now  self 
- `async-std` is replaced by `smol`